### PR TITLE
The project had conflicting build configurations, with files for both…

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,6 +143,6 @@
 </head>
   <body class="bg-white font-mono">
     <div id="root"></div>
-    <script src="/bundle.js" defer></script>
+    <script type="module" src="/index.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.1.0",
   "private": true,
   "scripts": {
-    "start": "esbuild index.tsx --bundle --outfile=bundle.js --jsx=automatic --servedir=. --watch",
-    "build": "mkdir -p dist && cp index.html dist/ && esbuild index.tsx --bundle --outfile=dist/bundle.js --jsx=automatic --minify"
+    "start": "vite",
+    "build": "vite build"
   },
   "dependencies": {
     "react": "^19.1.1",
@@ -13,7 +13,9 @@
   "devDependencies": {
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
     "esbuild": "^0.21.3",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vite": "^5.2.13"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,11 @@
 import path from 'path';
 import { defineConfig, loadEnv } from 'vite';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
+      plugins: [react()],
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)


### PR DESCRIPTION
… esbuild and Vite. This was likely causing the blank page issue on Vercel deployments.

This change standardizes the project to use Vite as the sole build tool.

- Updates `package.json` with Vite dependencies and scripts.
- Modifies `index.html` to use the correct Vite entry point.
- Configures `vite.config.ts` to include the React plugin.

This should resolve the deployment issue on Vercel.